### PR TITLE
Feat/#20/api연동 사용자인증

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_URL=http://localhost:3000
+NEXT_PUBLIC_BACKEND_URL=http://api.codementor.kro.kr

--- a/app/api/user/register/route.ts
+++ b/app/api/user/register/route.ts
@@ -1,0 +1,14 @@
+import {type NextRequest, NextResponse} from "next/server";
+
+const backendURL = process.env.NEXT_PUBLIC_BACKEND_URL;
+
+export default async function POST(request: NextRequest) {
+    const signUpFormData = await request.json();
+
+    const res = await fetch(`${backendURL}/api/user/register`,
+        {method: 'POST', body: JSON.stringify(signUpFormData), headers: {'Content-Type': 'application/json'}}
+    );
+
+    const data =  await res.json();
+    return NextResponse.json(data);
+}

--- a/app/api/user/userLogin/route.ts
+++ b/app/api/user/userLogin/route.ts
@@ -1,0 +1,35 @@
+import {type NextRequest, NextResponse} from "next/server";
+import {cookies} from "next/headers";
+import getRefreshToken from "@/service/getRefreshToken";
+
+const backendURL = process.env.NEXT_PUBLIC_BACKEND_URL;
+export default async function POST(req: NextRequest) {
+    const loginRequest = await req.json();
+
+    const res = await fetch(`${backendURL}/api/user/userLogin`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(loginRequest),
+        credentials: 'include'
+    });
+
+    if (res.ok) {
+        const {headers} = res;
+        const accessToken = headers.get('Authorization');
+        const setCookieHeader = headers.get("Set-Cookie");
+
+        if ((accessToken != null) && (setCookieHeader != null)) {
+            const {token, options} = getRefreshToken(setCookieHeader);
+
+            const cookieStore = cookies();
+            cookieStore.set("Access", accessToken);
+            cookieStore.set("Refresh", token, options);
+        }
+    }
+
+    const data = await res.json();
+    return NextResponse.json(data);
+
+}

--- a/app/login/layout.tsx
+++ b/app/login/layout.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import PageLayout from "@/components/common/PageLayout";
+
+function LogInLayout({children}:{children:React.ReactNode}) {
+    return (
+        <PageLayout>{children}</PageLayout>
+    );
+}
+
+export default LogInLayout;

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,46 +1,58 @@
+'use client';
+
 import React from 'react';
+import {useFormState} from "react-dom";
 import {Button} from "@nextui-org/react";
 import Link from "next/link";
 import Input from "@/components/common/Form";
 import Logo from "@/components/common/Header/Logo";
+import {userLogin} from "@/service/user";
+
+const initialState = {
+    message: '',
+    name: ''
+};
 
 function LoginPage() {
+    const [state, formAction] = useFormState(userLogin, initialState);
 
-  return (
-      <div className='w-fit min-h-[460px] mx-auto p-[20px] flex flex-col items-center space-y-[20px]
+    return (
+        <div className='w-fit min-h-[460px] mx-auto p-[20px] flex flex-col items-center space-y-[20px]
                             border border-[#e8e8e8] dark:border-[#464746] dark:bg-[#121212] shadow-lg'
-      >
-        <Logo className='min-w-[333px] mt-[50px] mb-[30px] text-3xl text-center'/>
-        <form
-            action=""
-            className='min-w-[340px] flex flex-col space-y-[20px]'
         >
-          <Input
-              type='text'
-              placeholder='닉네임 혹은 이메일'
-              errorMessage=''
-              className='w-full customInput'
-          />
-          <Input
-              type='password'
-              placeholder='비밀번호'
-              errorMessage=''
-              className='w-full customInput'
-          />
-          <Button
-              size='lg'
-              radius='sm'
-              className='bg-[#486471] dark:bg-[#476370] text-xl text-white'
-          >
-            로그인
-          </Button>
-        </form>
-        <div className='flex items-center w-full px-2'>
-          <Link href='/findPwd' className='mr-auto text-[#50707D] dark:text-[#82A3B1] text-sm'>비밀번호 찾기</Link>
-          <Link href='/signUp' className='ml-auto text-[#50707D] dark:text-[#82A3B1] text-sm'>회원가입</Link>
+            <Logo className='min-w-[333px] mt-[50px] mb-[30px] text-3xl text-center'/>
+            <form
+                action={formAction}
+                className='min-w-[340px] flex flex-col space-y-[20px]'
+            >
+                <Input
+                    type='text'
+                    name='usernameOrEmail'
+                    placeholder='닉네임 혹은 이메일'
+                    errorMessage=''
+                    className='w-full customInput'
+                />
+                <Input
+                    type='password'
+                    name='userPassword'
+                    placeholder='비밀번호'
+                    errorMessage=''
+                    className='w-full customInput'
+                />
+                <Button
+                    size='lg'
+                    radius='sm'
+                    className='bg-[#486471] dark:bg-[#476370] text-xl text-white'
+                >
+                    로그인
+                </Button>
+            </form>
+            <div className='flex items-center w-full px-2'>
+                <Link href='/findPwd' className='mr-auto text-[#50707D] dark:text-[#82A3B1] text-sm'>비밀번호 찾기</Link>
+                <Link href='/signUp' className='ml-auto text-[#50707D] dark:text-[#82A3B1] text-sm'>회원가입</Link>
+            </div>
         </div>
-      </div>
-  );
+    );
 }
 
 export default LoginPage;

--- a/app/signUp/layout.tsx
+++ b/app/signUp/layout.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import PageLayout from "@/components/common/PageLayout";
+
+function SignUpLayout({children}:{children:React.ReactNode}) {
+    return (
+        <PageLayout>
+            {children}
+        </PageLayout>
+    );
+}
+
+export default SignUpLayout;

--- a/app/signUp/page.tsx
+++ b/app/signUp/page.tsx
@@ -18,25 +18,25 @@ function SignUpPage() {
               type='text'
               placeholder='닉네임'
               errorMessage=''
-              className='w-full customInput'
+              className='w-full'
           />
           <Input
               type='password'
               placeholder='비밀번호'
               errorMessage=''
-              className='w-full customInput'
+              className='w-full'
           />
           <Input
               type='password'
               placeholder='비밀번호 확인'
               errorMessage=''
-              className='w-full customInput'
+              className='w-full'
           />
           <Input
               type='email'
               placeholder='이메일 주소'
               errorMessage=''
-              className='w-full customInput'
+              className='w-full'
           />
 
           <Button

--- a/app/signUp/page.tsx
+++ b/app/signUp/page.tsx
@@ -1,65 +1,110 @@
+'use client';
+
 import React from 'react';
+import {useFormState} from 'react-dom';
 import {Button} from "@nextui-org/react";
 import Link from "next/link";
 import Input from "@/components/common/Form";
 import Logo from "@/components/common/Header/Logo";
+import {register} from "@/service/user";
 
+const initialState = {
+    name:'',
+    message:''
+}
 function SignUpPage() {
-  return (
-      <div className='w-fit min-h-[600px] mx-auto p-[20px] flex flex-col items-center space-y-[20px]
-         border border-[#e8e8e8] dark:border-[#464746] dark:bg-[#121212] shadow-lg'
-      >
-        <Logo className='min-w-[333px] mt-[50px] mb-[30px] text-3xl text-center'/>
-        <form
-            action=""
-            className='min-w-[340px] flex flex-col space-y-[20px]'
-        >
-          <Input
-              type='text'
-              placeholder='닉네임'
-              errorMessage=''
-              className='w-full'
-          />
-          <Input
-              type='password'
-              placeholder='비밀번호'
-              errorMessage=''
-              className='w-full'
-          />
-          <Input
-              type='password'
-              placeholder='비밀번호 확인'
-              errorMessage=''
-              className='w-full'
-          />
-          <Input
-              type='email'
-              placeholder='이메일 주소'
-              errorMessage=''
-              className='w-full'
-          />
+    const [state, formAction] = useFormState(register, initialState);
 
-          <Button
-              size="lg"
-              radius="sm"
-              className="bg-[#486471] dark:bg-[#476370] text-xl text-white"
-          >
-            회원 가입
-          </Button>
-        </form>
-        <div className="w-full h-[70px] px-2 flex justify-center items-center space-x-4">
+    console.log("state::: ", state);
+
+    return (
+        <div className='w-fit min-h-[600px] mx-auto p-[20px] flex flex-col items-center space-y-[20px]
+         border border-[#e8e8e8] dark:border-[#464746] dark:bg-[#121212] shadow-lg'
+        >
+            <Logo className='min-w-[333px] mt-[50px] mb-[30px] text-3xl text-center'/>
+            <form
+                action={formAction}
+                className='min-w-[340px] flex flex-col space-y-[20px]'
+            >
+                <div className='flex flex-col space-y-2'>
+                    <Input
+                        type='text'
+                        name='nickname'
+                        placeholder='닉네임'
+                        errorMessage=''
+                        className='w-full'
+                        required
+                    />
+                    {/* { */}
+                    {/*     state.name === 'nickname' && */}
+                    {/*     <span className='pl-2 text-sm text-themeError'>{state.message}</span> */}
+                    {/* } */}
+                </div>
+                <div className='flex flex-col space-y-2'>
+                    <Input
+                        type='password'
+                        name='password'
+                        placeholder='비밀번호'
+                        errorMessage=''
+                        className='w-full'
+                        required
+                    />
+                    {/* { */}
+                    {/*     state.name === 'password' && */}
+                    {/*     <span className='pl-2 text-sm text-themeError'>{state.message}</span> */}
+                    {/* } */}
+                </div>
+
+                <div className='flex flex-col space-y-2'>
+                    <Input
+                        type='password'
+                        name='passwordCheck'
+                        placeholder='비밀번호 확인'
+                        errorMessage=''
+                        className='w-full'
+                        required
+                    />
+                    {/* { */}
+                    {/*     state.name === 'passwordCheck' && */}
+                    {/*     <span className='pl-2 text-sm text-themeError'>{state.message}</span> */}
+                    {/* } */}
+                </div>
+                <div className='flex flex-col space-y-2'>
+                    <Input
+                        type='email'
+                        name='email'
+                        placeholder='이메일 주소'
+                        errorMessage=''
+                        className='w-full'
+                        required
+                    />
+                    {/* { */}
+                    {/*     state.name === 'email' && */}
+                    {/*     <span className='pl-2 text-sm text-themeError'>{state.message}</span> */}
+                    {/* } */}
+                </div>
+                <Button
+                    type='submit'
+                    size="lg"
+                    radius="sm"
+                    className="bg-[#486471] dark:bg-[#476370] text-xl text-white"
+                >
+                    회원 가입
+                </Button>
+            </form>
+            <div className="w-full h-[70px] px-2 flex justify-center items-center space-x-4">
         <span className="text-[#50707D] text-md font-medium text-[#aaa]">
           계정이 있으신가요?
         </span>
-          <Link
-              href="/login"
-              className="text-[#50707D] text-md font-bold text-[#50707] dark:text-[#82A3B1]"
-          >
-            로그인
-          </Link>
+                <Link
+                    href="/login"
+                    className="text-[#50707D] text-md font-bold text-[#50707] dark:text-[#82A3B1]"
+                >
+                    로그인
+                </Link>
+            </div>
         </div>
-      </div>
-  );
+    );
 }
 
 export default SignUpPage;

--- a/components/common/Form/Input.tsx
+++ b/components/common/Form/Input.tsx
@@ -21,7 +21,7 @@ function Input({
     <div
       className={classNames(
         disabled ? 'opacity-50 pointer-events-none' : '',
-        `relative mobile:text-sm ${props.className ? props.className : ''}`
+        `relative mobile:text-sm`
       )}
     >
       {label !== '' && (
@@ -29,7 +29,7 @@ function Input({
           {label}
         </label>
       )}
-      <input id={props.id} type="text" {...props} className='customInput'/>
+      <input id={props.id} type="text" {...props} className={classNames(`${props.className ?? props.className}`,'customInput')}/>
       {errorMessage !== '' && (
         <p className="text-red-500 text-md">{errorMessage}</p>
       )}

--- a/components/common/PageLayout/PageLayout.tsx
+++ b/components/common/PageLayout/PageLayout.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function PageLayout({children}:{children:React.ReactNode}) {
+    return (
+        <section className='my-16'>
+            {children}
+        </section>
+    );
+}
+
+export default PageLayout;

--- a/components/common/PageLayout/index.tsx
+++ b/components/common/PageLayout/index.tsx
@@ -1,0 +1,3 @@
+import PageLayout from "@/components/common/PageLayout/PageLayout";
+
+export default PageLayout;

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+// todo : 백엔드 서버로 가는 요청 가로채서 토큰 세팅
+export function middleware(request: NextRequest) {
+    return NextResponse.redirect(new URL('/', request.url))
+}
+
+export const config = {
+    matcher: ['/api/user/:userBoard*','/api/user/:userInfo*']
+}

--- a/service/getRefreshToken.ts
+++ b/service/getRefreshToken.ts
@@ -1,0 +1,22 @@
+import camelCase from "next/dist/build/webpack/loaders/css-loader/src/camelcase";
+
+export default function getRefreshToken(setCookieHeader: string) {
+    let refreshTokenValue = "";
+    let cookieOptions = {};
+    setCookieHeader.split(";").map((item) => {
+        const cookieItem = item.trim().split("=");
+        if (cookieItem.includes("Refresh")) {
+            // eslint-disable-next-line prefer-destructuring
+            refreshTokenValue = cookieItem[1];
+        } else {
+            const optionName = camelCase(cookieItem[0]);
+            const optionValue = cookieItem[1] ?? true;
+            cookieOptions = {
+                ...cookieOptions,
+                [optionName]: optionValue,
+            };
+        }
+    });
+
+    return { token: refreshTokenValue, options: cookieOptions };
+}

--- a/service/requestWrapper.ts
+++ b/service/requestWrapper.ts
@@ -1,0 +1,32 @@
+import {type HTTP_METHOD} from "next/dist/server/web/http";
+import jsonReplaceBigInt from "@/utils/jsonReplaceBigInt";
+
+const publicURL = process.env.NEXT_PUBLIC_URL;
+const backendURL = process.env.NEXT_PUBLIC_BACKEND_URL;
+export const routeRequest = async (url: string, method: HTTP_METHOD, requestBody?: Record<string, any>) => {
+    const requestInit: RequestInit = {
+        method,
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    };
+
+    if (method !== 'GET' && requestBody != null) requestInit.body = jsonReplaceBigInt(requestBody);
+
+    const res = await fetch(`${publicURL}${url}`, requestInit);
+    return res.json();
+}
+
+export const request = async (url: string, method: HTTP_METHOD, requestBody?: Record<string, any>) => {
+    const requestInit: RequestInit = {
+        method,
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    };
+
+    if (method !== 'GET' && requestBody != null) requestInit.body = jsonReplaceBigInt(requestBody);
+
+    const res = await fetch(`${backendURL}${url}`, requestInit);
+    return res.json();
+}

--- a/service/user/index.ts
+++ b/service/user/index.ts
@@ -1,0 +1,6 @@
+import register from "@/service/user/register";
+import userLogin from "@/service/user/userLogin";
+import {request, routeRequest} from "@/service/requestWrapper";
+
+
+export {request, routeRequest, register, userLogin};

--- a/service/user/register.ts
+++ b/service/user/register.ts
@@ -1,0 +1,47 @@
+'use server';
+
+import {validateEmail, validateNickname, validatePasswordWithCheck} from "@/utils/formValidation";
+import {request} from "@/service/user/index";
+
+
+/**
+ * 회원가입
+ * @param prevState
+ * @param formData
+ */
+export default async function register(prevState: any, formData: FormData) {
+    const nickname = formData.get('nickname') as string;
+    const email = formData.get('email') as string;
+    const password = formData.get('password') as string;
+    const passwordCheck = formData.get('passwordCheck') as string;
+
+    const nickNameValidationMsg = validateNickname(nickname);
+    if (nickNameValidationMsg !== '') {
+        return {
+            name: 'nickname',
+            message: nickNameValidationMsg
+        }
+    }
+
+    const emailValidationMsg = validateEmail(email);
+    if (emailValidationMsg !== '') {
+        return {
+            name: 'email',
+            message: emailValidationMsg
+        }
+    }
+
+    const passwordValidationMsg = validatePasswordWithCheck(password, passwordCheck);
+
+    if (passwordValidationMsg !== '') {
+        return {
+            name: passwordValidationMsg.includes('확인') ? 'passwordCheck' : 'password',
+            message: passwordValidationMsg
+        }
+    }
+
+    const response = await request('/api/user/register', 'POST', {nickname, email, password});
+    const data = await response.json();
+    console.log("in user, data: ",data);
+    return data;
+}

--- a/service/user/userLogin.ts
+++ b/service/user/userLogin.ts
@@ -1,0 +1,25 @@
+'use server';
+
+import { validateEmail, validateNickname} from "@/utils/formValidation";
+import {validatePassword} from "@/utils/formValidation/formValidation";
+import {request} from "@/service/user/index";
+
+export default async function userLogin(prevState: any, formData: FormData) {
+    const usernameOrEmail = formData.get('usernameOrEmail') as string;
+    const userPassword = formData.get('userPassword') as string;
+
+    // usernameOrEmail validation
+    const validateNicknameMessage = usernameOrEmail.includes('@')
+        ? validateEmail(usernameOrEmail)
+        : validateNickname(usernameOrEmail);
+    if (validateNicknameMessage !== '') return {name: 'usernameOrEmail', message: validateNicknameMessage};
+
+    // userPassword validation
+    const validatePasswordMessage = validatePassword(userPassword)
+    if (validatePasswordMessage !== '') return {name: 'userPassword', message: validatePasswordMessage};
+
+    const res = await request('/api/user/userLogin','POST', {usernameOrEmail, userPassword});
+    const data = await res.json();
+
+    return data;
+};

--- a/service/user/userLogin.ts
+++ b/service/user/userLogin.ts
@@ -1,7 +1,6 @@
 'use server';
 
-import { validateEmail, validateNickname} from "@/utils/formValidation";
-import {validatePassword} from "@/utils/formValidation/formValidation";
+import { validateEmail, validateNickname, validatePassword} from "@/utils/formValidation";
 import {request} from "@/service/user/index";
 
 export default async function userLogin(prevState: any, formData: FormData) {

--- a/utils/formValidation/formValidation.ts
+++ b/utils/formValidation/formValidation.ts
@@ -1,0 +1,57 @@
+/**
+ * 이메일 형식 validation
+ * @param email
+ */
+export const validateEmail = (email:string) => {
+    if(email === '') return '이메일을 입력해주세요';
+
+    const emailRegex: RegExp = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if(!emailRegex.test(email)) return '올바른 이메일 형식이 아닙니다';
+
+    return '';
+}
+
+/**
+ * 닉네임 형식 validation (6-12 자리 영문 + 숫자)
+ * @param nickname
+ */
+export const validateNickname = (nickname: string) => {
+    if(nickname === '') return '닉네임을 입력해주세요';
+
+    const nicknameRegex: RegExp = /^[a-zA-Z0-9]{6,12}$/;
+    if(!nicknameRegex.test(nickname)) return '닉네임은 영문,숫자를 포함한 6~12 자리만 가능합니다';
+
+    return '';
+}
+
+export const isValidPassword = (password: string) => {
+    const passwordRegex: RegExp = /^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,12}$/
+    return passwordRegex.test(password);
+}
+
+/**
+ * 비밀번호, 비밀번호 확인 형식 validation (8-12 자리 특수문자 + 영문 + 숫자)
+ * @param password
+ */
+export const validatePasswordWithCheck = (password:string, passwordCheck:string) => {
+    if(password === '') return '비밀번호를 입력해 주세요.';
+    if(passwordCheck === '') return '비밀번호 확인을 입력해 주세요.';
+
+    if(password !== passwordCheck) return '비밀번호와 비밀번호 확인이 일치하지 않습니다.';
+
+    if(!isValidPassword(password)) return '비밀번호는 영문,숫자,특수기호를 포함한 8~12자리만 가능합니다.';
+
+
+    return '';
+}
+
+/**
+ * 비밀번호 형식 validation
+ * @param password
+ */
+export const validatePassword = (password:string) => {
+    if(password === '') return '비밀번호를 입력해 주세요.';
+    if(!isValidPassword(password)) return '비밀번호는 영문,숫자,특수기호를 포함한 8~12자리만 가능합니다.';
+
+    return '';
+}

--- a/utils/formValidation/index.ts
+++ b/utils/formValidation/index.ts
@@ -1,10 +1,1 @@
-import {
-    validateEmail,
-    validateNickname,
-    validatePasswordWithCheck
-}
-    from "@/utils/formValidation/formValidation";
-
-
-
-export {validateEmail, validateNickname, validatePasswordWithCheck};
+export * from "@/utils/formValidation/formValidation";

--- a/utils/formValidation/index.ts
+++ b/utils/formValidation/index.ts
@@ -1,0 +1,10 @@
+import {
+    validateEmail,
+    validateNickname,
+    validatePasswordWithCheck
+}
+    from "@/utils/formValidation/formValidation";
+
+
+
+export {validateEmail, validateNickname, validatePasswordWithCheck};

--- a/utils/jsonReplaceBigInt.ts
+++ b/utils/jsonReplaceBigInt.ts
@@ -1,0 +1,3 @@
+export default function jsonReplaceBigInt(data: Record<string, unknown>) {
+    return JSON.stringify(data, (k, v) => (typeof v === 'bigint' ? Number(v) : v));
+}


### PR DESCRIPTION
## 1. 연관된 이슈 번호

 #20 

<br>

## 2. 작업 내용

### 백엔드 서버 url 환경변수로 추가 
- b6e02a7bacd4ef646843475bbafecd8a4b878a0e

### fetch 요청 공통 wrapper 추가 
- c4b123f5dc151125adfcc76bad45cb7b5da94096

### api 요청, form validation에 쓰는 공통 util 추가 
- 9c038f2e9cbb0de3900be07b9f0701d14f93161d, 

### 로그인 api 연동
- d90a4f0c6ce44fdb83209832779e878a0b7ed405

### 회원가입 api 연동 
- fd1716978d9c693eaacff4225dc8085144bf8780, 4d7a006f6015c8d5674201bcbcc963618fa29e69

### middleware.ts 추가  
- 3ce98ac87149267cbd126cd41ea2970d40487cf1

: 인증필요한 요청 가로채서 토큰 세팅하기 위한 미들웨어입니다. 아직 구현 중입니다. 



<br>

## 3. 스크린샷 (선택사항)

<br>

## 4. 추가사항 및 리뷰 요구사항 (선택사항)
